### PR TITLE
Fix page title and page being too small or too big on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>title</title>
 	<link rel="stylesheet" href="styles.css">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body>
 	<div id="bodyDiv">

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>title</title>
+    <title>OpenRecipes</title>
 	<link rel="stylesheet" href="styles.css">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,6 @@
+html {
+	word-wrap: break-word;
+}
 h1 {
 	text-align: center;
 }


### PR DESCRIPTION
Added `word-wrap` in CSS and `<meta name="viewport" content="width=device-width, initial-scale=1.0">` to the html.